### PR TITLE
Fix install issues

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -11,7 +11,7 @@
 
 - name: install metricbeat
   apt:
-    name: metricbeat
+    name: "metricbeat={{ metricbeat_version }}"
     state: present
   notify:
     - restart metricbeat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - include: debian.yml
   when: ansible_os_family == 'Debian'
+  
+- include: redhat.yml
+  when: ansible_os_family == 'RedHat'
 
 - name: create metricbeat.yml
   template:


### PR DESCRIPTION
Included redhat.yml for installing on RedHat, similar to the current debian.yml include.

Set metricbeat_version to the package name when installing with apt.